### PR TITLE
feat: add method docs

### DIFF
--- a/go-tsgen/README.md
+++ b/go-tsgen/README.md
@@ -5,5 +5,5 @@ Generate a typescript declarations file for LotusRPC (FullNode API).
 ## Usage
 
 ```sh
-go run ./main.go
+go run ./
 ```

--- a/go-tsgen/docs.go
+++ b/go-tsgen/docs.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"strings"
+)
+
+type visitor struct {
+	Methods map[string]ast.Node
+}
+
+func (v *visitor) Visit(node ast.Node) ast.Visitor {
+	st, ok := node.(*ast.TypeSpec)
+	if !ok {
+		return v
+	}
+	if st.Name.Name != "FullNode" {
+		return nil
+	}
+	iface := st.Type.(*ast.InterfaceType)
+	for _, m := range iface.Methods.List {
+		if len(m.Names) > 0 {
+			v.Methods[m.Names[0].Name] = m
+		}
+	}
+	return v
+}
+
+func extractMethodDocs() map[string]string {
+	pkg, err := build.Import("github.com/filecoin-project/lotus/api", "", 0)
+	if err != nil {
+		panic(err)
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, pkg.Root+"/api", nil, parser.AllErrors|parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+
+	ap := pkgs["api"]
+	f := ap.Files[pkg.Root+"/api/api_full.go"]
+	cmap := ast.NewCommentMap(fset, f, f.Comments)
+	v := &visitor{make(map[string]ast.Node)}
+
+	ast.Walk(v, ap)
+
+	mdocs := make(map[string]string)
+	for mn, node := range v.Methods {
+		cs := cmap.Filter(node).Comments()
+		if len(cs) == 0 {
+			continue
+		}
+		last := cs[len(cs)-1].Text()
+		if !strings.HasPrefix(last, "MethodGroup:") {
+			mdocs[mn] = last
+		}
+	}
+	return mdocs
+}

--- a/go-tsgen/go.mod
+++ b/go-tsgen/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/alanshaw/go2ts v0.1.1
 	github.com/filecoin-project/go-address v0.0.4
-	github.com/filecoin-project/go-jsonrpc v0.1.2-0.20201008195726-68c6a2704e49
 	github.com/filecoin-project/go-state-types v0.0.0-20201003010437-c33112184a2b
 	github.com/filecoin-project/lotus v0.10.2
 	github.com/ipfs/go-cid v0.0.7

--- a/go-tsgen/go.sum
+++ b/go-tsgen/go.sum
@@ -238,6 +238,7 @@ github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b 
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/lotus v0.10.2 h1:1PSqy4juXAPHo33o+5PiDzXCWI/sb4RnH5y9nh/fCc0=
 github.com/filecoin-project/lotus v0.10.2/go.mod h1:ahNsMjh5iWm3w6W1kP9Uq/pPfAy8gvhJdEghYB0kEJI=
+github.com/filecoin-project/lotus v1.1.2 h1:cs74C5oNVoIIFmjovpSuJR3qXzXcqS9cpOT+oSmNRiE=
 github.com/filecoin-project/specs-actors v0.6.1/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.12 h1:iIvk58tuMtmloFNHhAOQHG+4Gci6Lui0n7DYQGi3cJk=

--- a/go-tsgen/main.go
+++ b/go-tsgen/main.go
@@ -84,6 +84,7 @@ func main() {
 		c.AddTypes(map[reflect.Type]string{t: name})
 	}
 
+	mdocs := extractMethodDocs()
 	methods := []string{"constructor (provider: any, options: { schema: any })"}
 	for i := 0; i < t.NumMethod(); i++ {
 		m := t.Method(i)
@@ -114,6 +115,17 @@ func main() {
 			ts = strings.Replace(ts, "ID ", "id ", 1)
 		} else {
 			ts = strings.ToLower(ts[0:1]) + ts[1:]
+		}
+		if doc, ok := mdocs[m.Name]; ok {
+			methods = append(methods, "/**")
+			lines := strings.Split(strings.TrimSpace(doc), "\n")
+			for i, line := range lines {
+				if i == 0 {
+					line = strings.ToLower(line[0:1]) + line[1:]
+				}
+				methods = append(methods, " * "+line)
+			}
+			methods = append(methods, " */")
 		}
 		methods = append(methods, ts)
 	}


### PR DESCRIPTION
This PR adds code to parse the comments in the API interfaces and add them as comments to the typescript declarations. This allows editors to display more information about the method in and _might allow us to generate nice docs for the JS API based on the TS declarations in the future_ 😉 .

**BEFORE**

<img width="833" alt="Screenshot 2020-10-25 at 20 45 26" src="https://user-images.githubusercontent.com/152863/97118648-12a3d680-1703-11eb-9f3a-dd3da757a4ee.png">

**AFTER**

<img width="856" alt="Screenshot 2020-10-25 at 20 42 18" src="https://user-images.githubusercontent.com/152863/97118577-9f01c980-1702-11eb-914c-781de061c734.png">

See https://github.com/filecoin-shipyard/js-lotus-client-rpc/pull/8
