### PR TITLE
exclude main files from build on windows

### DIFF
--- a/go-schemagen/github.go
+++ b/go-schemagen/github.go
@@ -1,0 +1,5 @@
+// +build windows
+
+// package github is a workaround for windows CI builds complaining about
+// no packages to test
+package github

--- a/go-schemagen/main.go
+++ b/go-schemagen/main.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (

--- a/go-tsgen/docs.go
+++ b/go-tsgen/docs.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (

--- a/go-tsgen/github.go
+++ b/go-tsgen/github.go
@@ -1,0 +1,5 @@
+// +build windows
+
+// package github is a workaround for windows CI builds complaining about
+// no packages to test
+package github

--- a/go-tsgen/main.go
+++ b/go-tsgen/main.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (


### PR DESCRIPTION
Just checking how we could avoid CI execution on windows. This skips any real work but fails with `no packages found` so we'll have to do better.